### PR TITLE
feat/thumbnail-fx

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -28,7 +28,8 @@ install: image_processing.c error_handling.c | install-dependencies
 	$(CC) $(CFLAGS) $(LDFLAGS) image_processing.o error_handling.o argparse.o -o $(BINDIR)/aestheticfx
 
 clean:
-	rm -f image_processing.o error_handling.o
+	rm -f image_processing.o error_handling.o argparse.o
+
 
 uninstall:
 	rm -f $(BINDIR)/aestheticfx

--- a/src/image_processing.c
+++ b/src/image_processing.c
@@ -2,6 +2,42 @@
 #include "../include/error_handling.h"
 
 int main(int argc, const char **argv) {
+    char *input_file = NULL;
+    char *output_file = NULL;
+    int thumbnail_fx = 0;
+    int flags_init = 0;
+
+    // Define the command line options
+    struct argparse_option options[] = {
+        OPT_HELP(),
+        OPT_STRING('i', "input", &input_file, "Input file"),
+        OPT_STRING('o', "output", &output_file, "Output file"),
+        OPT_BOOLEAN('t', "thumbnail", &thumbnail_fx, "Turn the images into a thumbnail sequence"),
+        OPT_END(),
+    };
+    const char *const usages[] = {
+        "aestheticfx [options] <input_file> <output_file>",
+        NULL
+    };
+
+    // Define the argument parser
+    struct argparse argparse;
+    argparse_init(&argparse, options, usages, flags_init);
+    argparse_describe(&argparse, "\nA program for image processing and manipulation.", NULL);
+    argparse_parse(&argparse, argc, argv);
+
+    // Check if the required arguments are missing
+    if (input_file == NULL || output_file == NULL) {
+        fprintf(stderr, "Invalid command-line arguments. See usage:\n");
+        argparse_usage(&argparse);
+        return(-1);
+    }
+
+    MagickBooleanType
+        status;
+
+    MagickWand
+        *magick_wand;
     /*
         Read an image.
     */
@@ -11,10 +47,16 @@ int main(int argc, const char **argv) {
     if (status == MagickFalse)
         ThrowWandException(magick_wand);
     
+    // Turn the image into a thumbnail sequence
     if (thumbnail_fx) {
         MagickResetIterator(magick_wand);
         while (MagickNextImage(magick_wand) != MagickFalse)
             MagickResizeImage(magick_wand, 106, 80, LanczosFilter);
+    }
+    else {
+        fprintf(stderr, "Invalid command-line arguments. See usage:\n");
+        argparse_usage(&argparse);
+        return(-1);
     }
     /*
         Write the image then destroy it.


### PR DESCRIPTION
### Add thumbnail sequence generation

This pull request introduces a new feature that allows the transformation of an image into a **thumbnail sequence**. The implemented code provides the capability to resize images to a thumbnail size of **106x80** pixels using the **Lanczos filter**. This enhancement improves the versatility of the image processing functionality and enables users to generate thumbnail sequences effortlessly.